### PR TITLE
feat: add pos_names, num_pos to knobs to support snapped knob labeling

### DIFF
--- a/CoreModules/elements/base_element.hh
+++ b/CoreModules/elements/base_element.hh
@@ -77,7 +77,7 @@ struct Pot : ParamElement {
 	std::string_view units = "";
 	bool integral = false;
 	uint8_t display_precision = 0;
-	constexpr static size_t MaxPosNames = 16;
+	constexpr static size_t MaxPosNames = 32;
 	unsigned num_pos = 0;
 	std::array<std::string_view, MaxPosNames> pos_names{};
 };

--- a/CoreModules/elements/base_element.hh
+++ b/CoreModules/elements/base_element.hh
@@ -77,6 +77,9 @@ struct Pot : ParamElement {
 	std::string_view units = "";
 	bool integral = false;
 	uint8_t display_precision = 0;
+	constexpr static size_t MaxPosNames = 16;
+	unsigned num_pos = 16;
+	std::array<std::string_view, MaxPosNames> pos_names{};
 };
 
 struct Knob : Pot {

--- a/CoreModules/elements/base_element.hh
+++ b/CoreModules/elements/base_element.hh
@@ -78,7 +78,7 @@ struct Pot : ParamElement {
 	bool integral = false;
 	uint8_t display_precision = 0;
 	constexpr static size_t MaxPosNames = 16;
-	unsigned num_pos = 16;
+	unsigned num_pos = 0;
 	std::array<std::string_view, MaxPosNames> pos_names{};
 };
 


### PR DESCRIPTION
@danngreen 

See title

One q - sorry if this is a naive question - I'm still not used to pre-allocating memory coming from the graces of a lot of other higher level languages. It it correct here to define a fixed max limit for the number of snapped positions that a knob can have? It seems bad that any potentially new port with more positions than `num_pos` will require us to update the firmware, and it also takes up space for knobs that don't need it. 